### PR TITLE
Add piece move support (using interstitial show page)

### DIFF
--- a/app/assets/stylesheets/pieces.css.scss
+++ b/app/assets/stylesheets/pieces.css.scss
@@ -1,0 +1,3 @@
+.selected-piece {
+ background-color: #EEB4B4;
+}

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,0 +1,27 @@
+class PiecesController < ApplicationController
+  before_action :set_piece, only: [:show, :update]
+  
+  def show
+    @game = Piece.find(params[:id]).game
+    @pieces = @game.pieces
+  end
+  
+  def update
+    if @piece.update_attributes(piece_params)
+      redirect_to @piece.game
+    else
+      render :show
+    end
+  end
+  
+  private
+  
+    def set_piece
+      @piece = Piece.find(params[:id])
+    end
+  
+    def piece_params
+      params.require(:piece).permit(:id, :x_coordinate, :y_coordinate)
+    end
+  
+end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -5,7 +5,7 @@
 	  <div class='chessboard-space'>
 	  <% @pieces.each do |piece| %>
 	  	<% if piece.x_coordinate == x && piece.y_coordinate == y %>
-				<%= link_to "#{piece.color[0]}#{piece.type}", '#', class: "chess-piece #{piece.color}-#{piece.type.downcase}" %>
+				<%= link_to "#{piece.color[0]}#{piece.type}", game_piece_path(@game, piece), class: "chess-piece #{piece.color}-#{piece.type.downcase}" %>
 		  <% end %>
 		<% end %>
 		</div>

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -1,0 +1,18 @@
+<div id='chessboard'>
+<% (1..8).each do |x| %>
+	<div class='board-row'> 
+	<% (1..8).each do |y| %>
+	  <% ( @piece.x_coordinate == x && @piece.y_coordinate == y ) ? selected_class = ' selected-piece' : selected_class = '' %>
+	  <div class="chessboard-space">
+      <% @pieces.each do |piece| %>
+  	    <% if piece.x_coordinate == x && piece.y_coordinate == y %>
+  			  <%= link_to "#{piece.color[0]}#{piece.type}", '', class: "chess-piece #{piece.color}-#{piece.type.downcase}#{selected_class}" %>
+  			<% else %>
+  			  <%= link_to '', game_piece_path(@piece.game, @piece, piece: { id: @piece, x_coordinate: x, y_coordinate: y }), method: 'PUT' %>
+  		  <% end %>
+  		<% end %>
+  	</div>
+	<% end %>
+  </div>
+<% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Chessapp::Application.routes.draw do
   
   root 'static_pages#index'
   
-  resources :games
+  resources :games, only: [:new, :create, :show] do
+    resources :pieces, only: [:show, :update]
+  end
 end


### PR DESCRIPTION
Using this code in the UI:
Click a piece to be directed to the Pieces show page. The piece link will highlight. Click an empty square, and the coordinates of the chosen piece will update, and the Game show page will re-render with the piece in the new location. (You can try to move a piece to a space already occupied, but you shouldn't be 
able to.)
