### PR TITLE
Determine if a friendly piece occupies target destination for moving piece

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,4 +48,5 @@ end
 
 # Use debugger
 # gem 'debugger', group: [:development, :test]
+
 gem 'pry', group: [:development, :test]

--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,4 @@ end
 
 # Use debugger
 # gem 'debugger', group: [:development, :test]
+gem 'pry', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
     builder (3.1.4)
+    coderay (1.1.1)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -64,6 +65,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    method_source (0.8.2)
     mime-types (1.25.1)
     minitest (4.7.5)
     multi_json (1.11.2)
@@ -73,6 +75,10 @@ GEM
     pg (0.18.4)
     polyglot (0.3.5)
     powerpack (0.1.1)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -115,6 +121,7 @@ GEM
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
+    slop (3.6.0)
     sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -151,6 +158,7 @@ DEPENDENCIES
   jbuilder (~> 1.2)
   jquery-rails
   pg
+  pry
   rails (= 4.0.1)
   rubocop
   sass-rails

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,5 +1,6 @@
 class PiecesController < ApplicationController
   before_action :set_piece, only: [:show, :update]
+  before_action :set_friendly_pieces, only: :update
   
   def show
     @game = Piece.find(params[:id]).game
@@ -7,17 +8,36 @@ class PiecesController < ApplicationController
   end
   
   def update
-    if @piece.update_attributes(piece_params)
-      redirect_to @piece.game
+    x = params[:piece][:x_coordinate].to_i
+    y = params[:piece][:y_coordinate].to_i
+
+    if @piece.valid_move?(x, y) && !friendly_piece_occupies_destination?(x, y)
+      flash[:success] = "Move was valid" if @piece.update_attributes(piece_params)
     else
-      render :show
+      flash[:danger] = "Move was invalid"
     end
+    
+    redirect_to @piece.game
   end
   
   private
   
     def set_piece
       @piece = Piece.find(params[:id])
+    end
+    
+    def set_friendly_pieces
+    # Collect non-captured friendly pieces, but not the currently-moving piece
+      @friendly_pieces ||= @piece.game.pieces.where(color: @piece.color, captured?: false).where.not(id: @piece)      
+    end
+    
+    def friendly_piece_occupies_destination?(x, y)
+    # Check if a friendly piece occupies the targeted destination  
+      @friendly_pieces.each do |friendly_piece|
+        return true if friendly_piece.x_coordinate == x && friendly_piece.y_coordinate == y
+      end
+      
+      false
     end
   
     def piece_params

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,13 +16,16 @@
   	<p class="alert alert-danger"><%= alert %></p>
   <% end %>
   
+  <% flash.each do |type, message| %>
+    <%= content_tag :div, message, class: "alert alert-#{type}" %>
+  <% end %>
+  
   <% if player_signed_in? %>
   	<li><%= link_to 'A player is signed in!', '#' %></li>
   <% else %>
   	<li><%= link_to 'No player is signed in :(', '#' %></li>
   <% end %>
 
-  <%= yield %>
-  
+    <%= yield %>
   </body>
 </html>

--- a/app/views/pieces/show.html.erb
+++ b/app/views/pieces/show.html.erb
@@ -6,7 +6,7 @@
 	  <div class="chessboard-space">
       <% @pieces.each do |piece| %>
   	    <% if piece.x_coordinate == x && piece.y_coordinate == y %>
-  			  <%= link_to "#{piece.color[0]}#{piece.type}", '', class: "chess-piece #{piece.color}-#{piece.type.downcase}#{selected_class}" %>
+  		 		<%= link_to "#{piece.color[0]}#{piece.type}", game_piece_path(piece.game, @piece, piece: { id: @piece, x_coordinate: x, y_coordinate: y }), method: 'PUT', class: "chess-piece #{piece.color}-#{piece.type.downcase}#{selected_class}" %>
   			<% else %>
   			  <%= link_to '', game_piece_path(@piece.game, @piece, piece: { id: @piece, x_coordinate: x, y_coordinate: y }), method: 'PUT' %>
   		  <% end %>

--- a/db/migrate/20160227232144_change_captured_default_in_pieces.rb
+++ b/db/migrate/20160227232144_change_captured_default_in_pieces.rb
@@ -1,0 +1,5 @@
+class ChangeCapturedDefaultInPieces < ActiveRecord::Migration
+  def change
+    change_column_default :pieces, :captured?, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160225212702) do
+ActiveRecord::Schema.define(version: 20160227232144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,7 +53,7 @@ ActiveRecord::Schema.define(version: 20160225212702) do
     t.string   "color"
     t.integer  "x_coordinate"
     t.integer  "y_coordinate"
-    t.boolean  "captured?"
+    t.boolean  "captured?",    default: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "game_id"


### PR DESCRIPTION
- Added logic to Pieces controller to determine if a friendly piece occupies the target destination of a moving piece
- Added pry gem for real-time debugging
- Added display of flash messages to application layout
- Updated Pieces show template to account for checking of valid piece moves
- Changed Pieces table to make captured? false by default

I thought it made more sense, and would be more performant, to check for this at the controller level...as opposed to making every piece ask for this in valid_move?. Maybe I'm wrong...
